### PR TITLE
feat(seo): add logo structured data in head

### DIFF
--- a/modules/header/LyonJSHead.tsx
+++ b/modules/header/LyonJSHead.tsx
@@ -12,5 +12,14 @@ export const LyonJSHead = () => (
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="theme-color" content="#ffffff" />
+      <script type="application/ld+json">
+          {JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "Organization",
+              "url": "http://lyonjs.org",
+              "logo": "http://lyonjs.org/android-chrome-512x512.png"
+          })
+          }
+      </script>
   </Head>
 );


### PR DESCRIPTION
## Why

We need to help Search Engine to percive our logo with structured data in order to let them display it in search results.

## How

- add structured data in head of the page

## How to validate

- copy the content of the page html
- go on [this website](https://search.google.com/test/rich-results)
- paste it and check for result
- you should see no error and a Logo rich result


