### PR TITLE
fix(a11y): fix missing lang attribut on pages

### DIFF
--- a/modules/header/LyonJSHead.tsx
+++ b/modules/header/LyonJSHead.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head';
 
 export const LyonJSHead = () => (
   <Head>
+    <html lang="fr-FR"/>
     <title>LyonJS - Communauté lyonnaise des utilisateurs de JavaScript</title>
     <meta name="description" content="Communauté lyonnaise des utilisateurs de JavaScript" />
     <link rel="icon" href="/favicon.ico" />


### PR DESCRIPTION
## Why

We need to specify the language used in the website for a11y purpose