### PR TITLE
fix(a11y): fix navigation a11y error and warning

### DIFF
--- a/modules/header/Header.tsx
+++ b/modules/header/Header.tsx
@@ -50,6 +50,7 @@ export const Header = () => {
                 target="_blank"
                 rel="noreferrer noopener"
                 title="La page Meetup du LyonJS"
+                aria-label="La page Meetup du LyonJS"
               >
                 <Meetup color="currentColor" size={24} />
               </a>
@@ -60,6 +61,7 @@ export const Header = () => {
                 target="_blank"
                 rel="noreferrer noopener"
                 title="Compte Twitter du LyonJS"
+                aria-label="Compte Twitter du LyonJS"
               >
                 <Twitter color="currentColor" size={24} />
               </a>
@@ -70,6 +72,7 @@ export const Header = () => {
                 target="_blank"
                 rel="noreferrer noopener"
                 title="Rejoindre le Slack du LyonJS"
+                aria-label="Rejoindre le Slack du LyonJS"
               >
                 <Slack color="currentColor" size={24} />
               </a>
@@ -80,6 +83,7 @@ export const Header = () => {
                 target="_blank"
                 rel="noreferrer noopener"
                 title="La chaîne Youtube du LyonJS"
+                aria-label="La chaîne Youtube du LyonJS"
               >
                 <Youtube color="currentColor" size={24} />
               </a>
@@ -90,6 +94,7 @@ export const Header = () => {
                 target="_blank"
                 rel="noreferrer noopener"
                 title="Groupe Reddit LyonJS"
+                aria-label="Groupe Reddit LyonJS"
               >
                 <Reddit color="currentColor" size={24} />
               </a>

--- a/modules/icons/LogoWithText.tsx
+++ b/modules/icons/LogoWithText.tsx
@@ -5,6 +5,7 @@ type Props = Omit<IconProps, 'size'> & { width: string; height: string };
 
 export const LogoWithText: React.FC<Props> = ({ width, height, color, backgroundColor }) => (
   <svg width={width} height={height} viewBox="0 0 1548 793" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <title>LyonJS</title>
     <path
       fillRule="evenodd"
       clipRule="evenodd"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -64,7 +64,6 @@ const Home: NextPage<Props> = ({ nextEvent, pastEvents }) => {
                   alt={sponsor.name}
                   width="200"
                   height="200"
-                  title={sponsor.name}
                   className="object-cover h-auto"
                 />
               </a>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -59,13 +59,7 @@ const Home: NextPage<Props> = ({ nextEvent, pastEvents }) => {
                 rel="noopener noreferrer"
                 className={sponsor.logoLight ? 'flex items-center bg-white' : 'flex items-center'}
               >
-                <Image
-                  src={sponsor.logo}
-                  alt={sponsor.name}
-                  width="200"
-                  height="200"
-                  className="object-cover h-auto"
-                />
+                <Image src={sponsor.logo} alt={sponsor.name} width="200" height="200" className="object-cover h-auto" />
               </a>
             ))}
           </div>


### PR DESCRIPTION
## Why

We need to have an accessible website for LyonJS orga

## How

- fix error in logo of LyonJS which did not have an accessible title.
- fix social link accessible name to let user understand what they are targeting
- fix duplicate title and alt on sponsor images

## How to validate

Open the preview and use https://wave.webaim.org/extension/ extension to check 