### PR TITLE
feat: add youtube links for meetup #80

### DIFF
--- a/data/data-override.ts
+++ b/data/data-override.ts
@@ -7,10 +7,12 @@ export const dataOverride: { [key: string]: Partial<Event> } = {
     talks: [
       {
         title: 'Projet XState',
+        videoLink: 'https://www.youtube.com/embed/HWRQp2Y1rbw',
         speakers: [{ name: 'Maxime Blanc', socialLink: 'https://twitter.com/jeansmaug' }],
       },
       {
         title: 'gRPC-web - Connecter son front en grpc',
+        videoLink: 'https://www.youtube.com/embed/U7em023u7SU',
         speakers: [{ name: 'Mohammad-Amine Banaei', socialLink: 'https://www.linkedin.com/in/mbnei/' }],
       },
     ],


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

In order to add the video recording of the session 80 in the website.

## 🧪 How to check them?

It should embbed the youtube video on the homepage
