### PR TITLE
fix: export mode is not compatbile with optimised images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,7 @@ const nextConfig = {
   distDir: 'dist',
   images: {
     domains: ['pbs.twimg.com'],
+    unoptimized: true, // disable as we use export mode (which is not compatible see https://nextjs.org/docs/messages/export-image-api)
   },
 };
 


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

Because the command `pnpm export` was broken when optimizing image.

## 🧑‍🔬 How did you make them?

I disable the image optimization for now until we fully use SSR with Vercel

