### PR TITLE
refactor(past-events): optimise get static path for past event page

### DIFF
--- a/modules/meetup/api.ts
+++ b/modules/meetup/api.ts
@@ -71,3 +71,29 @@ export const fetchMeetupEvents = async (): Promise<{ nextEvent: Event; pastEvent
 
   return { nextEvent, pastEvents };
 };
+
+const queryForYears = gql`
+  query meetupYears($id: ID!) {
+    group(id: $id) {
+      id
+      name
+      pastEvents(input: { first: 5000 }) {
+        edges {
+          node {
+            dateTime
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const fetchYearsWithMeetups = async (): Promise<Set<string>> => {
+  const meetupEventsResponse = await client.request<ResponseType>(queryForYears, { id: 18305583 });
+  const years = new Set<string>();
+  meetupEventsResponse?.group?.pastEvents?.edges.forEach((it) => {
+    years.add(new Date(it.node.dateTime).getFullYear().toString());
+  });
+
+  return years;
+};

--- a/pages/evenements-precedents/[year].tsx
+++ b/pages/evenements-precedents/[year].tsx
@@ -5,7 +5,7 @@ import { Event } from '../../modules/event/types';
 import { dataOverride } from '../../data/data-override';
 import _merge from 'lodash/merge';
 import _uniq from 'lodash/uniq';
-import { fetchMeetupEvents } from '../../modules/meetup/api';
+import { fetchMeetupEvents, fetchYearsWithMeetups } from '../../modules/meetup/api';
 import { ParsedUrlQuery } from 'querystring';
 import { H1 } from '../../modules/atoms/remark/Titles';
 import { YearNavigation } from '../../modules/event/past-events/YearNaviation';
@@ -42,14 +42,10 @@ const overrideEvent = (event: Event): Event => {
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const { pastEvents } = await fetchMeetupEvents();
-  const yearsFromEvents: string[] = pastEvents
-    .map((event) => new Date(event.dateTime).getFullYear())
-    .map((year) => year.toString());
-  const years = _uniq(yearsFromEvents);
+  const years = await fetchYearsWithMeetups();
 
   return {
-    paths: years.map((year) => ({ params: { year } })),
+    paths: Array.from(years).map((year) => ({ params: { year } })),
     fallback: false,
   };
 };


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

<!--
Explain the context of your changes in order to let reviewer understand what explains them.
-->

To generate all the pages from past events, I fetch all the details of the previous events.
We could only fetch date of events directly to make it more optimise I guess.

This could allow us to add link to past event page detail for inner nesting and SEO

## 🧑‍🔬 How did you make them?

<!--
List your intention of action by doing this PR
-->

- add new fetcher method

