### PR TITLE
feat(event-page): add slug in past event url

### DIFF
--- a/modules/event/eventSlug.ts
+++ b/modules/event/eventSlug.ts
@@ -1,0 +1,13 @@
+import type { Event } from './types';
+import { slugify } from '../seo/slugify';
+
+const EVENT_DELIMITER = '-e_';
+export const slugEventTitle = (event: Event) => `${slugify(event.title)}${EVENT_DELIMITER}${event.id}`;
+
+const parsingRegexp = /-e_(?<eventID>\d+)(\/|\?)?/;
+
+export const parserEventIdFromSlug = (slug: string) => {
+  const match = slug.match(parsingRegexp);
+
+  return match?.groups?.eventID;
+};

--- a/modules/seo/slugify.ts
+++ b/modules/seo/slugify.ts
@@ -1,0 +1,16 @@
+export function slugify(messageToSlug: string) {
+  const accentChars = 'àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìıİłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;';
+  const withoutAccent = 'aaaaaaaaaacccddeeeeeeeegghiiiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuuwxyyzzz------';
+  const regExpAccent = new RegExp(accentChars.split('').join('|'), 'g');
+
+  return messageToSlug
+    .toString()
+    .toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(regExpAccent, (char) => withoutAccent.charAt(accentChars.indexOf(char))) // Replace special characters
+    .replace(/&/g, '-and-') // Replace & with 'and'
+    .replace(/[^\w\-]+/g, '') // Remove all non-word characters
+    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, ''); // Trim - from end of text
+}

--- a/pages/evenement/[eventSlug].tsx
+++ b/pages/evenement/[eventSlug].tsx
@@ -2,12 +2,11 @@ import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import { fetchMeetupEvents } from '../../modules/meetup/api';
 import _uniq from 'lodash/uniq';
 import { ParsedUrlQuery } from 'querystring';
-import { dataOverride } from '../../data/data-override';
-import _merge from 'lodash/merge';
 import { LyonJSHead } from '../../modules/header/LyonJSHead';
 import { Event } from '../../modules/event/types';
 import { H1 } from '../../modules/atoms/remark/Titles';
 import React from 'react';
+import { slugify } from '../../modules/seo/slugify';
 
 const EventPage: NextPage<{ event: Event }> = ({ event }) => {
   return (
@@ -23,33 +22,26 @@ const EventPage: NextPage<{ event: Event }> = ({ event }) => {
     </>
   );
 };
-
-const overrideEvent = (event: Event): Event => {
-  if (event && dataOverride[event.eventUrl]) {
-    return _merge(event, dataOverride[event.eventUrl]);
-  }
-  return event;
-};
 export const getStaticPaths: GetStaticPaths = async () => {
   const { pastEvents } = await fetchMeetupEvents();
 
   return {
-    paths: pastEvents.map((event) => ({ params: { event: event.id } })),
+    paths: pastEvents.map((event) => ({ params: { eventSlug: `${slugify(event.title)}-e_${event.id}` } })),
     fallback: false,
   };
 };
 
 interface Params extends ParsedUrlQuery {
-  event: string;
+  eventSlug: string;
 }
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const { pastEvents } = await fetchMeetupEvents();
-  const { event } = context.params as Params;
+  const { eventSlug } = context.params as Params;
 
   return {
     props: {
-      event: pastEvents.find((e) => e.id === event),
+      event: pastEvents.find((e) => e.id === eventSlug.split('-e_')[1]),
     },
   };
 };

--- a/pages/evenement/[eventSlug].tsx
+++ b/pages/evenement/[eventSlug].tsx
@@ -1,12 +1,11 @@
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import { fetchMeetupEvents } from '../../modules/meetup/api';
-import _uniq from 'lodash/uniq';
 import { ParsedUrlQuery } from 'querystring';
 import { LyonJSHead } from '../../modules/header/LyonJSHead';
 import { Event } from '../../modules/event/types';
 import { H1 } from '../../modules/atoms/remark/Titles';
 import React from 'react';
-import { slugify } from '../../modules/seo/slugify';
+import { parserEventIdFromSlug, slugEventTitle } from '../../modules/event/eventSlug';
 
 const EventPage: NextPage<{ event: Event }> = ({ event }) => {
   return (
@@ -26,7 +25,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const { pastEvents } = await fetchMeetupEvents();
 
   return {
-    paths: pastEvents.map((event) => ({ params: { eventSlug: `${slugify(event.title)}-e_${event.id}` } })),
+    paths: pastEvents.map((event) => ({ params: { eventSlug: slugEventTitle(event) } })),
     fallback: false,
   };
 };
@@ -38,10 +37,11 @@ interface Params extends ParsedUrlQuery {
 export const getStaticProps: GetStaticProps = async (context) => {
   const { pastEvents } = await fetchMeetupEvents();
   const { eventSlug } = context.params as Params;
+  console.log(parserEventIdFromSlug(eventSlug));
 
   return {
     props: {
-      event: pastEvents.find((e) => e.id === eventSlug.split('-e_')[1]),
+      event: pastEvents.find((e) => e.id === parserEventIdFromSlug(eventSlug)),
     },
   };
 };

--- a/pages/evenements-precedents/[year].tsx
+++ b/pages/evenements-precedents/[year].tsx
@@ -12,6 +12,7 @@ import { YearNavigation } from '../../modules/event/past-events/YearNaviation';
 import { EventTile } from '../../modules/event/past-events/EventTile';
 import Link from 'next/link';
 import { slugify } from '../../modules/seo/slugify';
+import { slugEventTitle } from '../../modules/event/eventSlug';
 
 const Event: NextPage<{ pastEvents: Event[]; years: string[]; year: string }> = ({ pastEvents, years, year }) => {
   return (
@@ -26,7 +27,7 @@ const Event: NextPage<{ pastEvents: Event[]; years: string[]; year: string }> = 
         <YearNavigation years={years} />
 
         {pastEvents.map((event) => (
-          <Link key={event.eventUrl} href={`/evenement/${slugify(event.title)}-e_${event.id}`}>
+          <Link key={event.eventUrl} href={`/evenement/${slugEventTitle(event)}`}>
             <EventTile event={event} />
           </Link>
         ))}

--- a/pages/evenements-precedents/[year].tsx
+++ b/pages/evenements-precedents/[year].tsx
@@ -11,6 +11,7 @@ import { H1 } from '../../modules/atoms/remark/Titles';
 import { YearNavigation } from '../../modules/event/past-events/YearNaviation';
 import { EventTile } from '../../modules/event/past-events/EventTile';
 import Link from 'next/link';
+import { slugify } from '../../modules/seo/slugify';
 
 const Event: NextPage<{ pastEvents: Event[]; years: string[]; year: string }> = ({ pastEvents, years, year }) => {
   return (
@@ -25,7 +26,7 @@ const Event: NextPage<{ pastEvents: Event[]; years: string[]; year: string }> = 
         <YearNavigation years={years} />
 
         {pastEvents.map((event) => (
-          <Link key={event.eventUrl} href={`/evenement/${event.id}`}>
+          <Link key={event.eventUrl} href={`/evenement/${slugify(event.title)}-e_${event.id}`}>
             <EventTile event={event} />
           </Link>
         ))}


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

<!--
Explain the context of your changes in order to let reviewer understand what explains them.
-->

For SEO purpose, past event url should contain text related to page content with slugs.
It will add words for SEO
Let's implement it

## 🧑‍🔬 How did you make them?

<!--
List your intention of action by doing this PR
-->

- add classical slugify function 
- generate event url with slug

## 🧪 How to check them?

<!--
Explain how reviewer could check that you did not break anything
-->

- take a look a event page url
