### PR TITLE
feat: add youtube replays in event page

### DIFF
--- a/data/data-override.ts
+++ b/data/data-override.ts
@@ -1,17 +1,90 @@
 import type { Event } from '../modules/event/types';
-import { bedrock, indy, smile, zenika } from './sponsors';
+import { bedrock, indy, malt, smile, zenika } from './sponsors';
 
 export const dataOverride: { [key: string]: Partial<Event> } = {
+  'https://www.meetup.com/lyonjs/events/261928293': {
+    talks: [
+      {
+        title: 'Timeboxed TDD & TCR : Boostez votre Time to Market en dansant le Limbo',
+        speakers: [
+          {
+            name: 'Younes Jaaidi',
+          },
+        ],
+        videoLink: 'https://www.youtube.com/embed/p_0T0SCMuOQ',
+      },
+    ],
+  },
+  'https://www.meetup.com/lyonjs/events/274713264': {
+    sponsor: zenika,
+    talks: [
+      {
+        title: 'Back to the Vue (tour) 3',
+        speakers: [
+          {
+            name: 'Mathieu Mure',
+          },
+          {
+            name: 'Moustapha Agack',
+          },
+        ],
+        videoLink: 'https://www.youtube.com/embed/uKlPuuWzzOk',
+      },
+    ],
+  },
+  'https://www.meetup.com/lyonjs/events/266113861': {
+    sponsor: malt,
+    talks: [
+      {
+        title: 'Optimistic UI, principes et implémentations',
+        speakers: [
+          {
+            name: 'Clément Jacquelin',
+          },
+          {
+            name: 'Maxence Dalmais',
+          },
+        ],
+        videoLink: 'https://www.youtube.com/embed/OAslPGcaq1s',
+      },
+    ],
+  },
+  'https://www.meetup.com/lyonjs/events/292744601': {
+    sponsor: malt,
+    talks: [
+      {
+        title: 'Getting started with Nuxt 3 modules',
+        speakers: [{ name: 'Nicolas Payot', socialLink: 'https://twitter.com/npayot' }],
+        videoLink: 'https://www.youtube.com/embed/NtJHCe22XD8',
+      },
+      {
+        title: 'Comment gagner 1000€ en 35 minutes avec du CSS ',
+        speakers: [{ name: 'Geoffroy Begouassel', socialLink: 'https://twitter.com/npayot' }],
+        videoLink: 'https://www.youtube.com/embed/4sDZ8nArSqM',
+      },
+    ],
+  },
+  'https://www.meetup.com/lyonjs/events/291958869': {
+    talks: [
+      {
+        title: 'Playwright 🎭, the Cypress killer by Microsoft',
+        speakers: [{ name: 'Mathieu Mure', socialLink: 'https://twitter.com/mathieumure' }],
+        videoLink: 'https://www.youtube.com/embed/UDyBHzoMpV4',
+      },
+    ],
+  },
   'https://www.meetup.com/lyonjs/events/291728436': {
     sponsor: indy,
     talks: [
       {
         title: "Comment on n'a (toujours) pas codé de back-end après 9 mois en production ?",
         speakers: [{ name: 'Marc Gavanier', socialLink: 'https://twitter.com/MGavanier' }],
+        videoLink: 'https://www.youtube.com/embed/k2DWPBqmlH4',
       },
       {
         title: 'Mob Programming : ensemble on va plus loin',
         speakers: [{ name: 'Nicolas Poirier', socialLink: 'https://twitter.com/NicolasPoir' }],
+        videoLink: 'https://www.youtube.com/embed/GCNbh0Le5k4',
       },
     ],
   },

--- a/modules/event/components/EventDetail.module.css
+++ b/modules/event/components/EventDetail.module.css
@@ -48,3 +48,14 @@
     height: 120px;
   }
 }
+
+.replays {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.replays iframe {
+  display: block;
+  aspect-ratio: 16/9;
+}

--- a/modules/event/components/EventDetail.tsx
+++ b/modules/event/components/EventDetail.tsx
@@ -29,6 +29,12 @@ export const EventDetail: React.FC<Props> = ({ event }) => {
           <img src={event.imageUrl} alt="" className={styles.image} />
           <Location event={event} />
         </div>
+
+        <div className={styles.replays}>
+          {event.talks?.map((talk) => (
+            <iframe key={talk.title} width="100%" height="auto" src={talk.videoLink} loading="lazy" />
+          ))}
+        </div>
       </div>
     </>
   );

--- a/modules/event/components/EventTile.module.css
+++ b/modules/event/components/EventTile.module.css
@@ -52,7 +52,10 @@
   margin-bottom: 6px;
 }
 
-.eventTile .sponsor {
+.eventTile .footer {
+  display: flex;
+  gap: 8px;
+  flex-direction: column;
   font-size: 0.875rem;
   line-height: 1.2;
   margin-top: 1rem;
@@ -60,4 +63,8 @@
 
 .eventTile .sponsor b {
   font-weight: 700;
+}
+
+.eventTile .replay svg {
+  display: inline;
 }

--- a/modules/event/components/EventTile.tsx
+++ b/modules/event/components/EventTile.tsx
@@ -2,11 +2,13 @@ import type { Event } from '../types';
 import dayjs from 'dayjs';
 import styles from './EventTile.module.css';
 import _capitalize from 'lodash/capitalize';
+import { Youtube } from '../../icons/Youtube';
 
 type Props = { event: Event };
 export const EventTile: React.FC<Props> = ({ event }) => {
   const dateParsed = dayjs(event.dateTime);
   const formattedDayAndMonth = _capitalize(dateParsed.format('dddd D MMMM YYYY à H:mm'));
+  const hasReplay = event.talks?.some((talk) => talk.videoLink);
 
   return (
     <article className={styles.eventTile} aria-label={event.title}>
@@ -14,11 +16,18 @@ export const EventTile: React.FC<Props> = ({ event }) => {
       <div className={styles.content}>
         <h2>{event.title}</h2>
         <div className={styles.time}>{formattedDayAndMonth}</div>
-        {event.sponsor && (
-          <div className={styles.sponsor}>
-            Sponsorisé par <b>{event.sponsor.name}</b>
-          </div>
-        )}
+        <div className={styles.footer}>
+          {event.sponsor && (
+            <div className={styles.sponsor}>
+              Sponsorisé par <b>{event.sponsor.name}</b>
+            </div>
+          )}
+          {hasReplay && (
+            <div className={styles.replay}>
+              Replay disponible <Youtube color="currentColor" size={16} />
+            </div>
+          )}
+        </div>
       </div>
     </article>
   );

--- a/pages/evenement/[eventSlug].tsx
+++ b/pages/evenement/[eventSlug].tsx
@@ -8,6 +8,7 @@ import { EventMarkup } from '../../modules/event/components/EventMarkup';
 import { parserEventIdFromSlug, slugEventTitle } from '../../modules/event/eventSlug';
 import { fetchEvent } from '../../modules/meetup/queries/event.api';
 import { fetchPastEvents } from '../../modules/meetup/queries/past-events.api';
+import { overrideEvent } from '../../modules/event/overrideEvent';
 
 const EventPage: NextPage<{ event: Event }> = ({ event }) => {
   return (
@@ -41,7 +42,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
   const eventId = parserEventIdFromSlug(eventSlug);
   let event;
   if (eventId) {
-    event = await fetchEvent(eventId);
+    event = overrideEvent(await fetchEvent(eventId));
   }
 
   return {


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

<!--
Explain the context of your changes in order to let reviewer understand what explains them.
-->

We want to expose our video replays directly in our website

## 🧑‍🔬 How did you make them?

<!--
List your intention of action by doing this PR
-->

- add small message in event tile to show that replays are available
- add embed player in event page when available
- use lazy loaded player in order not to slowdown page loading
- add last event video replays

