### PR TITLE
feat: add replay thumbnail and link within home page

### DIFF
--- a/modules/home/LastReplays.module.css
+++ b/modules/home/LastReplays.module.css
@@ -1,0 +1,21 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: min(2vw, 16px);
+}
+
+@media (min-width: 900px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.grid img {
+  display: block;
+  max-height: 220px;
+  object-fit: cover;
+}
+
+.grid a {
+  border-radius: min(2vw, 12px);
+}

--- a/modules/home/LastReplays.tsx
+++ b/modules/home/LastReplays.tsx
@@ -1,0 +1,38 @@
+import React, { FC, useMemo } from 'react';
+import { Article, H2 } from './Home.components';
+import styles from './LastReplays.module.css';
+import type { Event, Talk } from '../event/types';
+import Link from 'next/link';
+import { slugEventTitle } from '../event/eventSlug';
+
+type Item = {
+  event: Event;
+  talk: Talk;
+  videoId: string;
+};
+
+export const LastReplays: FC<{ pastEvents: Event[] }> = ({ pastEvents }) => {
+  const replayLinks: Item[] = useMemo(() => {
+    return pastEvents.reduce((accumulator: Item[], event: Event) => {
+      const newEvents = event.talks?.map((talk: Talk) => ({
+        talk,
+        event,
+        videoId: talk.videoLink?.split(/embed\//)[1],
+      })) as Item[];
+      return [...accumulator, ...newEvents] as Item[];
+    }, []);
+  }, [pastEvents]);
+
+  return (
+    <Article>
+      <H2>Nos derniers replays</H2>
+      <div className={styles.grid}>
+        {replayLinks.map(({ talk, event, videoId }) => (
+          <Link href={`/evenement/${slugEventTitle(event)}`} key={talk?.title}>
+            <img src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`} alt={talk?.title} />
+          </Link>
+        ))}
+      </div>
+    </Article>
+  );
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,10 +10,12 @@ import { HomeHero } from '../modules/home/HomeHero';
 import { NoNextEvent } from '../modules/home/NoNextEvent';
 import { EventCard } from '../modules/event/components/EventCard';
 import { overrideEvent } from '../modules/event/overrideEvent';
+import { fetchPastEvents } from '../modules/meetup/queries/past-events.api';
+import { LastReplays } from '../modules/home/LastReplays';
 
-type Props = { nextEvent: Event };
+type Props = { nextEvent: Event; pastEvents: Event[] };
 
-const Home: NextPage<Props> = ({ nextEvent }) => (
+const Home: NextPage<Props> = ({ nextEvent, pastEvents }) => (
   <>
     <LyonJSHead />
     <main>
@@ -23,6 +25,7 @@ const Home: NextPage<Props> = ({ nextEvent }) => (
         {nextEvent ? <EventCard event={nextEvent} /> : <NoNextEvent />}
       </Article>
       <SeePastEvents />
+      <LastReplays pastEvents={pastEvents} />
       <Sponsors />
     </main>
   </>
@@ -30,10 +33,15 @@ const Home: NextPage<Props> = ({ nextEvent }) => (
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
   const nextEvent = await fetchNextEvent();
+  const pastEvents = await fetchPastEvents();
 
   return {
     props: {
       nextEvent: overrideEvent(nextEvent),
+      pastEvents: pastEvents
+        .map(overrideEvent)
+        .filter((event) => event.talks?.some((talk) => talk.videoLink))
+        .slice(0, 6),
     },
   };
 };


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

<!--
Explain the context of your changes in order to let reviewer understand what explains them.
-->

Related to #134 

In order to maximise inner linking of lyonjs website, we should have more link our previous meetups directly in the homepage.

I tried to add a new section showing the last 6 video replays from our meetups. 

The design is not exactly what I had in mind, image uploaded in video thumbnail are not fullscreen 😢 )

## 🧑‍🔬 How did you make them?

<!--
List your intention of action by doing this PR
-->

- fetch past events in home page and render a new component

## 🧪 How to check them?

<!--
Explain how reviewer could check that you did not break anything
-->

See homepage
