### PR TITLE
fix: mobile navigation not closed when changing route

### DIFF
--- a/modules/navigation/mobile/MobileNavigation.tsx
+++ b/modules/navigation/mobile/MobileNavigation.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { MobileNavigationButton } from './button/MobileNavigationButton';
 import styles from './MobileNavigation.module.css';
@@ -8,11 +8,11 @@ import { MobileNavigationPanel } from './panel/MobileNavigationPanel';
 export const MobileNavigation = () => {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const route = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     setIsExpanded(false);
-  }, [route]);
+  }, [pathname]);
 
   useEffect(() => {
     document.body.toggleAttribute('data-lock-scroll', isExpanded);


### PR DESCRIPTION
Close #163 

## 🤔 Why do you want to make those changes?

The mobile navigation is broken

## 🧑‍🔬 How did you make them?

use `usePathname` instead of `useRouter` to detect a route change

## 🧪 How to check them?

- On the preview, resize the screen to view the mobile navigation
- the navigation panel should close when changing the route
