### PR TITLE
feat(navigation): make a Navlink active on nested navigation

### DIFF
--- a/app/evenements-precedents/page.tsx
+++ b/app/evenements-precedents/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect(`/evenements-precedents/${new Date().getFullYear()}`);
+}

--- a/modules/navigation/Navbar.tsx
+++ b/modules/navigation/Navbar.tsx
@@ -10,7 +10,9 @@ export const Navbar: FC<HTMLAttributes<HTMLElement>> = ({ className }) => (
         <NavLink href="/">Accueil</NavLink>
       </li>
       <li>
-        <NavLink href={`/evenements-precedents/${new Date().getFullYear()}`}>Évènements</NavLink>
+        <NavLink href={'/evenements-precedents'} activeOnNestedRoute>
+          Évènements
+        </NavLink>
       </li>
       <li>
         <NavLink href="/a-propos">À&nbsp;propos</NavLink>

--- a/modules/navigation/links/NavLink.tsx
+++ b/modules/navigation/links/NavLink.tsx
@@ -5,11 +5,12 @@ import { usePathname } from 'next/navigation';
 import { FC } from 'react';
 import styles from './NavLink.module.css';
 
-type NavLinkProps = React.ComponentProps<typeof Link>;
+type NavLinkProps = React.ComponentProps<typeof Link> & { activeOnNestedRoute?: boolean };
 
-export const NavLink: FC<NavLinkProps> = ({ children, href, ...rest }) => {
+export const NavLink: FC<NavLinkProps> = ({ children, href, activeOnNestedRoute = false, ...rest }) => {
   const pathname = usePathname();
-  const ariaCurrent = href === pathname ? 'page' : undefined;
+  const isActive = activeOnNestedRoute ? pathname.startsWith(href.toString()) : pathname === href;
+  const ariaCurrent = isActive ? 'page' : undefined;
 
   return (
     <Link href={href} aria-current={ariaCurrent} className={styles.link} {...rest}>


### PR DESCRIPTION
close #89
## 🤔 Why do you want to make those changes?
When we are on the `/evenements-precedents/2022` page the NavLink `Evenement` is not active and should be.

The condition checked for a NavLink to be active is an equality between the 'href' and the 'pathname'
The problem happens when we dynamic routes nested inside a route in the navbar

## 🧑‍🔬 How did you make them?

- Passed a new prop : `activeOnNestedRoute` to enable a navlink to be active when navigating a nested route
- Changed the NavLink href `/evenements-precedents/${new Date().getFullYear()}` -> `/evenements-precedents`
- Created a page `/evenements-precedents` that makes a server-side redirection to /evenements-precedents/${new Date().getFullYear()}`

<!--
List your intention of action by doing this PR
-->

## 🧪 How to check them?

- Go to the preview
- Click on the `Evenements` link, you should be redirected to /evenements-precedents/2023
- After the redirection, the said link should be active and stay active when you click the 2022 tab for example

<!--
Explain how reviewer could check that you did not break anything
-->
