### PR TITLE
feat(pastEvent): poc usage of next/og for open-graph image

### DIFF
--- a/app/a-propos/opengraph-image.tsx
+++ b/app/a-propos/opengraph-image.tsx
@@ -1,0 +1,17 @@
+import { ImageResponse } from 'next/og';
+import { SimpleText } from '../../modules/og/SimpleText';
+
+export const runtime = 'edge';
+
+export const alt = 'À propos de LyonJS';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = 'image/png';
+
+export default async function Image() {
+  return new ImageResponse(<SimpleText text={`À propos de LyonJS`} />, {
+    ...size,
+  });
+}

--- a/app/a-propos/opengraph-image.tsx
+++ b/app/a-propos/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { SimpleText } from '../../modules/og/SimpleText';
 
 export const runtime = 'edge';
 
-export const alt = 'À propos de LyonJS';
+export const alt = "À propos de l'association";
 export const size = {
   width: 1200,
   height: 630,

--- a/app/code-de-conduite/opengraph-image.tsx
+++ b/app/code-de-conduite/opengraph-image.tsx
@@ -1,0 +1,17 @@
+import { ImageResponse } from 'next/og';
+import { SimpleText } from '../../modules/og/SimpleText';
+
+export const runtime = 'edge';
+
+export const alt = 'Code de conduite';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = 'image/png';
+
+export default async function Image() {
+  return new ImageResponse(<SimpleText text={`Notre code de conduite`} />, {
+    ...size,
+  });
+}

--- a/app/evenements-precedents/[year]/opengraph-image.tsx
+++ b/app/evenements-precedents/[year]/opengraph-image.tsx
@@ -1,0 +1,68 @@
+import { ImageResponse } from 'next/og';
+export const runtime = 'edge';
+
+export const alt = 'About Acme'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+export const contentType = 'image/png'
+
+export default async function Image({ params: { year } }: { params: { year: string } }) {
+  const image = fetch(new URL('../../../public/android-chrome-192x192.png', import.meta.url)).then(
+    (res) => res.arrayBuffer(),
+  );
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          backgroundColor: 'black',
+          backgroundSize: '150px 150px',
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          textAlign: 'center',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+          flexWrap: 'nowrap',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            justifyItems: 'center',
+          }}
+        >
+          <img
+            alt="Vercel"
+            height={200}
+            src={image as unknown as string}
+            style={{ margin: '0 30px' }}
+            width={232}
+          />
+        </div>
+        <div
+          style={{
+            fontSize: 60,
+            fontStyle: 'normal',
+            letterSpacing: '-0.025em',
+            color: 'white',
+            marginTop: 30,
+            padding: '0 120px',
+            lineHeight: 1.4,
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          {`Nos évènements de l'année ${year}`}
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/app/evenements-precedents/[year]/opengraph-image.tsx
+++ b/app/evenements-precedents/[year]/opengraph-image.tsx
@@ -1,7 +1,8 @@
 import { ImageResponse } from 'next/og';
+import { SimpleText } from '../../../modules/og/SimpleText';
 export const runtime = 'edge';
 
-export const alt = 'About Acme';
+export const alt = 'LyonJS logo';
 export const size = {
   width: 1200,
   height: 630,
@@ -9,56 +10,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image({ params: { year } }: { params: { year: string } }) {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          backgroundColor: 'black',
-          backgroundSize: '150px 150px',
-          height: '100%',
-          width: '100%',
-          display: 'flex',
-          textAlign: 'center',
-          alignItems: 'center',
-          justifyContent: 'center',
-          flexDirection: 'column',
-          flexWrap: 'nowrap',
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            justifyItems: 'center',
-          }}
-        >
-          <img
-            alt="Vercel"
-            height={200}
-            src="https://lyonjs.org/android-chrome-192x192.png"
-            style={{ margin: '0 30px', objectFit: 'cover' }}
-            width={232}
-          />
-        </div>
-        <div
-          style={{
-            fontSize: 60,
-            fontStyle: 'normal',
-            letterSpacing: '-0.025em',
-            color: 'white',
-            marginTop: 30,
-            padding: '0 120px',
-            lineHeight: 1.4,
-            whiteSpace: 'pre-wrap',
-          }}
-        >
-          {`Nos évènements de l'année ${year}`}
-        </div>
-      </div>
-    ),
-    {
-      ...size,
-    },
-  );
+  return new ImageResponse(<SimpleText text={`Nos évènements de l'année ${year}`} />, {
+    ...size,
+  });
 }

--- a/app/evenements-precedents/[year]/opengraph-image.tsx
+++ b/app/evenements-precedents/[year]/opengraph-image.tsx
@@ -1,18 +1,14 @@
 import { ImageResponse } from 'next/og';
 export const runtime = 'edge';
 
-export const alt = 'About Acme'
+export const alt = 'About Acme';
 export const size = {
   width: 1200,
   height: 630,
-}
-export const contentType = 'image/png'
+};
+export const contentType = 'image/png';
 
 export default async function Image({ params: { year } }: { params: { year: string } }) {
-  const image = fetch(new URL('../../../public/android-chrome-192x192.png', import.meta.url)).then(
-    (res) => res.arrayBuffer(),
-  );
-
   return new ImageResponse(
     (
       <div
@@ -40,8 +36,8 @@ export default async function Image({ params: { year } }: { params: { year: stri
           <img
             alt="Vercel"
             height={200}
-            src={image as unknown as string}
-            style={{ margin: '0 30px' }}
+            src="https://lyonjs.org/android-chrome-192x192.png"
+            style={{ margin: '0 30px', objectFit: 'cover' }}
             width={232}
           />
         </div>
@@ -63,6 +59,6 @@ export default async function Image({ params: { year } }: { params: { year: stri
     ),
     {
       ...size,
-    }
+    },
   );
 }

--- a/modules/og/SimpleText.tsx
+++ b/modules/og/SimpleText.tsx
@@ -1,0 +1,49 @@
+export const SimpleText = ({ text }: { text: string }) => {
+  return (
+    <div
+      style={{
+        backgroundColor: 'black',
+        backgroundSize: '150px 150px',
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        textAlign: 'center',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        flexWrap: 'nowrap',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          justifyItems: 'center',
+        }}
+      >
+        <img
+          alt="Vercel"
+          height={200}
+          src="https://lyonjs.org/android-chrome-512x512.png"
+          style={{ margin: '0 30px', objectFit: 'cover' }}
+          width={232}
+        />
+      </div>
+      <div
+        style={{
+          fontSize: 60,
+          fontStyle: 'normal',
+          letterSpacing: '-0.025em',
+          color: 'white',
+          marginTop: 30,
+          padding: '0 120px',
+          lineHeight: 1.4,
+          whiteSpace: 'pre-wrap',
+        }}
+      >
+        {text}
+      </div>
+    </div>
+  );
+};

--- a/modules/og/SimpleText.tsx
+++ b/modules/og/SimpleText.tsx
@@ -1,3 +1,5 @@
+import { LogoWithText } from '../icons/LogoWithText';
+
 export const SimpleText = ({ text }: { text: string }) => {
   return (
     <div
@@ -22,13 +24,7 @@ export const SimpleText = ({ text }: { text: string }) => {
           justifyItems: 'center',
         }}
       >
-        <img
-          alt="Vercel"
-          height={200}
-          src="https://lyonjs.org/android-chrome-512x512.png"
-          style={{ margin: '0 30px', objectFit: 'cover' }}
-          width={232}
-        />
+        <LogoWithText color="#ffffff" width="340px" />
       </div>
       <div
         style={{


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

<!--
Explain the context of your changes in order to let reviewer understand what explains them.
-->

Let's generate dynamically image for markup for our past events year page.
Very simple design for now, just to test the feature.

## 🧑‍🔬 How did you make them?

<!--
List your intention of action by doing this PR
-->

- [follow official doc of nextjs
](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image)

## 🧪 How to check them?

<!--
Explain how reviewer could check that you did not break anything
-->

- open preview and check for open-graph meta for past event pages
