### PR TITLE
feat(csp): enable nonce in nextjs

### DIFF
--- a/app/evenement/[slug]/page.tsx
+++ b/app/evenement/[slug]/page.tsx
@@ -8,19 +8,24 @@ import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 
 export const revalidate = 3600;
+
 export default async function EventPage({ params: { slug } }: { params: { slug: string } }) {
   const eventId = parserEventIdFromSlug(slug);
   if (!eventId) {
     notFound();
   }
-  const event = overrideEvent(await fetchEvent(eventId));
+  try {
+    const event = overrideEvent(await fetchEvent(eventId));
 
-  return (
-    <main>
-      <EventDetail event={event} />
-      <EventMarkup event={event} />
-    </main>
-  );
+    return (
+      <main>
+        <EventDetail event={event} />
+        <EventMarkup event={event} />
+      </main>
+    );
+  } catch (e) {
+    notFound();
+  }
 }
 
 export async function generateMetadata({ params: { slug } }: { params: { slug: string } }): Promise<Metadata> {
@@ -28,20 +33,24 @@ export async function generateMetadata({ params: { slug } }: { params: { slug: s
   if (!eventId) {
     return {};
   }
-  const event = overrideEvent(await fetchEvent(eventId));
-  const title = `LyonJS | ${event.title}`;
-  const description = `Évènement LyonJS: ${event.shortDescription || event.description.slice(0, 250)}...`;
+  try {
+    const event = overrideEvent(await fetchEvent(eventId));
+    const title = `LyonJS | ${event.title}`;
+    const description = `Évènement LyonJS: ${event.shortDescription || event.description.slice(0, 250)}...`;
 
-  return {
-    title,
-    description,
-    twitter: {
+    return {
       title,
       description,
-    },
-    openGraph: {
-      title,
-      description,
-    },
-  };
+      twitter: {
+        title,
+        description,
+      },
+      openGraph: {
+        title,
+        description,
+      },
+    };
+  } catch (e) {
+    return {};
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Metadata, Viewport } from 'next';
 import React, { ReactNode } from 'react';
+import { headers } from 'next/headers';
 import { Header } from '../modules/header/Header';
 import { Footer } from '../modules/footer/Footer';
 import { Analytics } from '@vercel/analytics/react';
@@ -14,6 +15,8 @@ import { ORGANISATION_MARKUP } from './org-markup';
 dayjs.locale('fr');
 
 export default function AppLayout({ children }: { children: ReactNode }) {
+  const nonce = headers().get('x-nonce');
+
   return (
     <html lang="fr-FR">
       <body>
@@ -21,6 +24,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
           <Header />
           <script
             type="application/ld+json"
+            nonce={`${nonce}`}
             dangerouslySetInnerHTML={{
               __html: JSON.stringify(ORGANISATION_MARKUP),
             }}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
             type="application/ld+json"
             nonce={`${nonce}`}
             dangerouslySetInnerHTML={{
-              __html: JSON.stringify(ORGANISATION_MARKUP),
+              __html: JSON.stringify(ORGANISATION_MARKUP).replaceAll('</', '<\\/'),
             }}
           />
           {children}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+  const cspHeader = `
+    default-src 'none';
+    script-src 'self' 'nonce-${nonce}' https://vercel.live/;
+    img-src 'self' 'nonce-${nonce}' https://secure-content.meetupstatic.com/ https://images.ctfassets.net/ https://assets.vercel.com/ https://secure.meetupstatic.com/ https://img.youtube.com/;
+    style-src 'self' 'unsafe-inline';
+    frame-src https://www.youtube.com/ https://vercel.live/;
+    manifest-src 'self';
+    object-src 'none';
+    form-action 'none';
+    connect-src 'self' https://vitals.vercel-insights.com/;
+    font-src 'self';
+    base-uri 'self';
+    frame-ancestors 'none';
+    block-all-mixed-content;
+    upgrade-insecure-requests;
+`;
+  // Replace newline characters and spaces
+  const contentSecurityPolicyHeaderValue = cspHeader.replace(/\s{2,}/g, ' ').trim();
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+
+  requestHeaders.set('Content-Security-Policy', contentSecurityPolicyHeaderValue);
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+  response.headers.set('Content-Security-Policy', contentSecurityPolicyHeaderValue);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    {
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,7 +11,7 @@ export function middleware(request: NextRequest) {
     manifest-src 'self';
     object-src 'none';
     form-action 'none';
-    connect-src 'self' https://vitals.vercel-insights.com/;
+    connect-src 'self' https://vitals.vercel-insights.com/ https://vercel.live/;
     font-src 'self';
     base-uri 'self';
     frame-ancestors 'none';

--- a/modules/event/types.ts
+++ b/modules/event/types.ts
@@ -28,6 +28,9 @@ export type Event = {
   dateTime: string;
   imageUrl: string;
   going: number;
+  group: {
+    id: string;
+  };
   venue: {
     name: string;
     address: string;

--- a/modules/meetup/queries/event.api.ts
+++ b/modules/meetup/queries/event.api.ts
@@ -1,6 +1,6 @@
 import { gql } from 'graphql-request';
 import { Event } from '../../event/types';
-import { client } from '../api';
+import { client, LYONJS_MEETUP_ID } from '../api';
 
 const query = gql`
   query meetup($id: ID!) {
@@ -14,6 +14,9 @@ const query = gql`
         photoSample(amount: 10) {
           source
         }
+      }
+      group {
+        id
       }
       venue {
         name
@@ -32,5 +35,10 @@ type Response = {
 };
 export const fetchEvent = async (id: string): Promise<Event> => {
   const response = await client.request<Response>(query, { id });
+
+  if (response?.event.group.id !== `${LYONJS_MEETUP_ID}`) {
+    throw Error(`event of id is not part of LyonJS`);
+  }
+
   return response?.event;
 };

--- a/modules/seo/JsonLD.tsx
+++ b/modules/seo/JsonLD.tsx
@@ -2,7 +2,7 @@ export const JsonLD: React.FC<{ jsonObject: unknown }> = ({ jsonObject }) => (
   <script
     type="application/ld+json"
     dangerouslySetInnerHTML={{
-      __html: JSON.stringify(jsonObject).replaceAll('/', '\\/'),
+      __html: JSON.stringify(jsonObject).replaceAll('</', '<\\/'),
     }}
   />
 );

--- a/modules/seo/JsonLD.tsx
+++ b/modules/seo/JsonLD.tsx
@@ -2,7 +2,7 @@ export const JsonLD: React.FC<{ jsonObject: unknown }> = ({ jsonObject }) => (
   <script
     type="application/ld+json"
     dangerouslySetInnerHTML={{
-      __html: JSON.stringify(jsonObject),
+      __html: JSON.stringify(jsonObject).replaceAll('/', '\\/'),
     }}
   />
 );

--- a/next.config.js
+++ b/next.config.js
@@ -1,28 +1,5 @@
 const withMDX = require('@next/mdx')();
 
-const ContentSecurityPolicy = `
-  default-src 'none';
-  script-src 'self' 'unsafe-inline' https://vercel.live/;
-  img-src 'self' https://secure-content.meetupstatic.com/ https://images.ctfassets.net/ https://assets.vercel.com/ https://secure.meetupstatic.com/ https://img.youtube.com/;
-  style-src 'self' 'unsafe-inline';
-  frame-src https://www.youtube.com/ https://vercel.live/;
-  manifest-src 'self';
-  object-src 'none';
-  form-action 'none';
-  connect-src 'self' https://vitals.vercel-insights.com/;
-`;
-
-let CSP_RULE = [];
-
-if (process.env.NODE_ENV !== 'development') {
-  CSP_RULE = [
-    {
-      key: 'Content-Security-Policy',
-      value: ContentSecurityPolicy.replace(/\s{2,}/g, ' ').trim(),
-    },
-  ];
-}
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
@@ -64,7 +41,6 @@ const nextConfig = {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()',
           },
-          ...CSP_RULE,
         ],
       },
     ];


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

<!--
Explain the context of your changes in order to let reviewer understand what explains them.
-->

As presented yesterday, `nonce` feature is now possible with NextJS so let's add it to the projet !

Also apply some feedback from @lightdiscord about XSS injection in our JSONLD scripts
Also apply check on event to be sure we render event from our group only

## 🧑‍🔬 How did you make them?

<!--
List your intention of action by doing this PR
-->

- add constraint on fetch event to be sure event are part of LyonJS meetup before rendering past event pages (look this funny one here https://www.lyonjs.org/evenement/90-webassembly-and-mozilla-observatory-e_298437484)
- add replace on JSONLD render in order to block `</script>` tag injection
- activate nonce on CSP rules in order to block inline script without nonce

## 🧪 How to check them?

<!--
Explain how reviewer could check that you did not break anything
-->

- check homepage
- check list of past events
- check past event page
- check that event page with id of other meetup group are now in 404 https://lyonjs-website-git-nonce-and-checks-lyonjs.vercel.app/evenement/90-webassembly-and-mozilla-observatory-e_298437484
