### PR TITLE
fix(ci): replace deprecated registry-image arg with image in scw CLI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -137,7 +137,6 @@ jobs:
             "${{ vars.SCW_PROD_CONTAINER_ID }}" \
             image="${{ needs.docker.outputs.scw_image }}" \
             region=fr-par
-          scw container container redeploy "${{ vars.SCW_PROD_CONTAINER_ID }}" region=fr-par
 
           # Poll until ready (timeout 3 min)
           for i in $(seq 1 36); do
@@ -194,7 +193,6 @@ jobs:
               "${EXISTING}" \
               image="${IMAGE}" \
               region=fr-par
-            scw container container redeploy "${EXISTING}" region=fr-par
             CONTAINER_ID="${EXISTING}"
           else
             echo "Creating new preview container"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           scw container container update \
             "${{ vars.SCW_PROD_CONTAINER_ID }}" \
-            registry-image="${{ needs.docker.outputs.scw_image }}" \
+            image="${{ needs.docker.outputs.scw_image }}" \
             redeploy=true \
             region=fr-par
 
@@ -192,7 +192,7 @@ jobs:
             echo "Updating existing container ${EXISTING}"
             scw container container update \
               "${EXISTING}" \
-              registry-image="${IMAGE}" \
+              image="${IMAGE}" \
               redeploy=true \
               region=fr-par
             CONTAINER_ID="${EXISTING}"
@@ -201,7 +201,7 @@ jobs:
             RESULT=$(scw container container create \
               namespace-id="${NAMESPACE_ID}" \
               name="${CONTAINER_NAME}" \
-              registry-image="${IMAGE}" \
+              image="${IMAGE}" \
               port=3000 \
               min-scale=0 \
               max-scale=1 \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -217,7 +217,7 @@ jobs:
             CONTAINER_ID=$(echo "$RESULT" | jq -r '.id')
 
             # Deploy the newly created container
-            scw container container deploy "${CONTAINER_ID}" region=fr-par
+            scw container container redeploy "${CONTAINER_ID}" region=fr-par
           fi
 
           # Poll until ready (timeout 3 min)

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -205,7 +205,7 @@ jobs:
               port=3000 \
               min-scale=0 \
               max-scale=1 \
-              memory-limit-bytes=268435456 \
+              memory-limit-bytes=0.25GB \
               mvcpu-limit=250 \
               privacy=public \
               https-connections-only=true \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -136,8 +136,8 @@ jobs:
           scw container container update \
             "${{ vars.SCW_PROD_CONTAINER_ID }}" \
             image="${{ needs.docker.outputs.scw_image }}" \
-            redeploy=true \
             region=fr-par
+          scw container container redeploy "${{ vars.SCW_PROD_CONTAINER_ID }}" region=fr-par
 
           # Poll until ready (timeout 3 min)
           for i in $(seq 1 36); do
@@ -193,8 +193,8 @@ jobs:
             scw container container update \
               "${EXISTING}" \
               image="${IMAGE}" \
-              redeploy=true \
               region=fr-par
+            scw container container redeploy "${EXISTING}" region=fr-par
             CONTAINER_ID="${EXISTING}"
           else
             echo "Creating new preview container"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -205,10 +205,10 @@ jobs:
               port=3000 \
               min-scale=0 \
               max-scale=1 \
-              memory-limit=256 \
-              cpu-limit=250 \
+              memory-limit-bytes=268435456 \
+              mvcpu-limit=250 \
               privacy=public \
-              http-option=redirected \
+              https-connections-only=true \
               environment-variables.DEPLOY_ENV=preview \
               environment-variables.NODE_ENV=production \
               environment-variables.HOSTNAME=0.0.0.0 \


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

The Scaleway CLI renamed the registry-image argument to image. All three update/create container calls were using the old name, causing deploy jobs to fail with 'Unknown argument registry-image'.